### PR TITLE
Fix #8: Change hamburgerClicked variable from local to global scope

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -108,9 +108,9 @@
     <script>
         /* When the user clicks on the button,
         toggle between hiding and showing the dropdown content */
+        let hamburgerClicked = false;
 
         function setupElements() {
-            let hamburgerClicked = false;
             var element = select('button');
             element.touchStarted(clickedHamburger);
             element = select("body");

--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
     <script>
         /* When the user clicks on the button,
         toggle between hiding and showing the dropdown content */
+        let hamburgerClicked = false;
 
         function setupElements() {
-            let hamburgerClicked = false;
             var element = select('button');
             element.touchStarted(clickedHamburger);
             element = select("body");

--- a/merch/index.html
+++ b/merch/index.html
@@ -96,9 +96,9 @@
     <script>
         /* When the user clicks on the button,
         toggle between hiding and showing the dropdown content */
+        let hamburgerClicked = false;
 
         function setupElements() {
-            let hamburgerClicked = false;
             var element = select('button');
             element.touchStarted(clickedHamburger);
             element = select("body");

--- a/projectOld.html
+++ b/projectOld.html
@@ -97,9 +97,9 @@
     <script>
         /* When the user clicks on the button,
         toggle between hiding and showing the dropdown content */
+        let hamburgerClicked = false;
 
         function setupElements() {
-            let hamburgerClicked = false;
             var element = select('button');
             element.touchStarted(clickedHamburger);
             element = select("body");

--- a/projects/WorldsHardestGame/index.html
+++ b/projects/WorldsHardestGame/index.html
@@ -87,9 +87,9 @@
     <script>
         /* When the user clicks on the button,
         toggle between hiding and showing the dropdown content */
+        let hamburgerClicked = false;
 
         function setupElements() {
-            let hamburgerClicked = false;
             var element = select('button');
             element.touchStarted(clickedHamburger);
             element = select("body");


### PR DESCRIPTION
This issue addresses issue #8. On screens larger than 700 pixels (as defined as the breakpoint in the code), the `hamburgerClicked` variable cannot be found when the `clickedBody` function is called, since the hamburger menu is not shown to the user and the variable is never properly initialized.

This behavior leads to the following error message:
```
Uncaught ReferenceError: hamburgerClicked is not defined
    clickedBody http://thebigcb.com/merch/:110
```

This PR will move the `hamburgerClicked` variable to the global scope for each page it is used in. By doing this, regardless of the screen size, the `hamburgerClicked` variable is immediately initialized to `false` and will continue to work as expected if the screen is less than 700 pixels and will not present an error in the console if the screen is larger than 700 pixels.